### PR TITLE
support django 1.6

### DIFF
--- a/tinylinks/tests/urls.py
+++ b/tinylinks/tests/urls.py
@@ -4,10 +4,14 @@ As you know, every app must be hooked into yout main ``urls.py`` so that
 you can actually reach the app's views (provided it has any views, of course).
 
 """
-from django.conf.urls.defaults import include, patterns, url
 from django.contrib import admin
 
 from tinylinks.tests.views import TestFailedRedirectView, TestRedirectView
+
+try:
+    from django.conf.urls import include, patterns, url
+except ImportError:  # Django < 1.6 fallback
+    from django.conf.urls.defaults import include, patterns, url
 
 
 admin.autodiscover()

--- a/tinylinks/urls.py
+++ b/tinylinks/urls.py
@@ -1,5 +1,4 @@
 """URLs for the ``django-tinylinks`` app."""
-from django.conf.urls.defaults import patterns, url
 from django.views.generic import TemplateView
 
 from tinylinks.views import (
@@ -10,6 +9,11 @@ from tinylinks.views import (
     TinylinkRedirectView,
     TinylinkUpdateView,
 )
+
+try:
+    from django.conf.urls import patterns, url
+except ImportError:  # Django < 1.6 fallback
+    from django.conf.urls.defaults import patterns, url
 
 
 urlpatterns = patterns(


### PR DESCRIPTION
Django 1.6+ changes the location of `include`, `patterns`, and `url`. This uses the new location, falling back to the old for any Django < 1.6
