### PR TITLE
fix pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include AUTHORS
 include CHANGELOG
 include LICENSE
 include README.rst
+include requirements.txt
 recursive-include tinylinks/templates *
 recursive-include tinylinks/tests/test_app/templates *
 recursive-include tinylinks/tests/test_app/fixtures *


### PR DESCRIPTION
This adds requirements.txt to the tarball so the package can be installed from PyPi. Here is the output from an attempted install as it stands:

```
Collecting django-tinylinks==0.7
  Downloading django-tinylinks-0.7.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-rTSHOe/django-tinylinks/setup.py", line 6, in <module>
        install_requires = open('requirements.txt').read().splitlines()
    IOError: [Errno 2] No such file or directory: 'requirements.txt'
```